### PR TITLE
Clete AI PR: Fix: POS Invoice warehouse permission error

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -566,6 +566,7 @@
    "depends_on": "update_stock",
    "fieldname": "set_warehouse",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Source Warehouse",
    "options": "Warehouse",
    "print_hide": 1

--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
@@ -607,6 +607,7 @@
   {
    "fieldname": "warehouse",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Warehouse",
    "oldfieldname": "warehouse",


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: Fix: POS Invoice warehouse permission error

Here's the [detailed postmortem analysis](https://app.clete.ai/execution?exec_id=97103c9c90&entity_ref=user_1&no_setup_check=1)