### PR TITLE
Clete AI PR: Fix warehouse permission error in POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -636,7 +636,15 @@ class POSInvoice(SalesInvoice):
 			self.account_for_change_amount = (
 				profile.get("account_for_change_amount") or self.account_for_change_amount
 			)
-			self.set_warehouse = profile.get("warehouse") or self.set_warehouse
+			
+			# Check warehouse permission before setting from profile
+			profile_warehouse = profile.get("warehouse")
+			if profile_warehouse and frappe.has_permission("Warehouse", "read", profile_warehouse):
+				self.set_warehouse = profile_warehouse or self.set_warehouse
+			elif not self.set_warehouse:
+				# If no warehouse is set and user doesn't have permission to profile warehouse,
+				# keep the current set_warehouse value (which might be None)
+				pass
 
 			for fieldname in (
 				"currency",

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -973,6 +973,74 @@ class TestPOSInvoice(IntegrationTestCase):
 			frappe.db.rollback(save_point="before_test_delivered_serial_no_case")
 			frappe.set_user("Administrator")
 
+	def test_warehouse_permission_in_pos_profile(self):
+		"""Test that POS Invoice respects warehouse permissions when setting warehouse from POS Profile"""
+		frappe.db.savepoint("before_test_warehouse_permission")
+		try:
+			# Create a test warehouse
+			test_warehouse = frappe.get_doc({
+				"doctype": "Warehouse",
+				"warehouse_name": "Test Restricted Warehouse",
+				"company": "_Test Company"
+			}).insert()
+			
+			# Create a POS Profile with the restricted warehouse
+			pos_profile = frappe.get_doc({
+				"doctype": "POS Profile",
+				"name": "Test Restricted Profile",
+				"company": "_Test Company",
+				"warehouse": test_warehouse.name,
+				"currency": "INR",
+				"write_off_account": "_Test Write Off - _TC",
+				"write_off_cost_center": "_Test Cost Center - _TC",
+				"payments": [{
+					"mode_of_payment": "Cash",
+					"default": 1
+				}]
+			}).insert()
+			
+			# Create a test user without warehouse permission
+			test_user = "test_pos_user@example.com"
+			if not frappe.db.exists("User", test_user):
+				user_doc = frappe.get_doc({
+					"doctype": "User",
+					"email": test_user,
+					"first_name": "Test",
+					"last_name": "POS User",
+					"user_type": "System User"
+				}).insert()
+			
+			# Set user and create POS Invoice
+			frappe.set_user(test_user)
+			
+			# Create POS Invoice - should not fail even without warehouse permission
+			pos_inv = frappe.get_doc({
+				"doctype": "POS Invoice",
+				"company": "_Test Company",
+				"pos_profile": pos_profile.name,
+				"customer": "_Test Customer",
+				"items": [{
+					"item_code": "_Test Item",
+					"qty": 1,
+					"rate": 100
+				}],
+				"payments": [{
+					"mode_of_payment": "Cash",
+					"amount": 100
+				}]
+			})
+			
+			# This should not raise a permission error
+			pos_inv.set_missing_values()
+			
+			# The warehouse should not be set if user doesn't have permission
+			# or should be set to None/empty if no permission
+			self.assertTrue(pos_inv.set_warehouse is None or pos_inv.set_warehouse == "")
+			
+		finally:
+			frappe.db.rollback(save_point="before_test_warehouse_permission")
+			frappe.set_user("Administrator")
+
 
 def create_pos_invoice(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: Fix warehouse permission error in POS Invoice

Here's the [detailed postmortem analysis](https://app.clete.ai/execution?exec_id=51894fc46c&entity_ref=user_1&no_setup_check=1)