### PR TITLE
Clete AI PR: Fix warehouse permission error in POS Invoice creation

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -636,7 +636,24 @@ class POSInvoice(SalesInvoice):
 			self.account_for_change_amount = (
 				profile.get("account_for_change_amount") or self.account_for_change_amount
 			)
-			self.set_warehouse = profile.get("warehouse") or self.set_warehouse
+			
+			# Check warehouse permission before setting it
+			profile_warehouse = profile.get("warehouse")
+			if profile_warehouse:
+				# Check if user has permission to the warehouse from POS Profile
+				if frappe.has_permission("Warehouse", "read", profile_warehouse):
+					self.set_warehouse = profile_warehouse
+				elif not self.set_warehouse:
+					# If user doesn't have permission to profile warehouse and no warehouse is set,
+					# try to find a warehouse the user has permission to
+					from frappe.core.doctype.user_permission.user_permission import get_permitted_documents
+					permitted_warehouses = get_permitted_documents("Warehouse")
+					if permitted_warehouses:
+						# Use the first permitted warehouse
+						self.set_warehouse = permitted_warehouses[0]
+			elif not self.set_warehouse:
+				# If no warehouse in profile and none currently set, use the original logic
+				self.set_warehouse = profile_warehouse
 
 			for fieldname in (
 				"currency",

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -973,6 +973,83 @@ class TestPOSInvoice(IntegrationTestCase):
 			frappe.db.rollback(save_point="before_test_delivered_serial_no_case")
 			frappe.set_user("Administrator")
 
+	def test_warehouse_permission_in_pos_invoice(self):
+		"""Test that POS Invoice handles warehouse permissions correctly when strict user permissions are applied"""
+		from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
+		
+		frappe.db.savepoint("before_test_warehouse_permission")
+		try:
+			# Create a test warehouse
+			test_warehouse = frappe.get_doc({
+				"doctype": "Warehouse",
+				"warehouse_name": "Test Warehouse for POS Permission",
+				"company": "_Test Company",
+				"parent_warehouse": "_Test Warehouse Group - _TC"
+			})
+			test_warehouse.insert()
+			
+			# Create a POS Profile with the test warehouse
+			pos_profile = make_pos_profile(
+				name="Test POS Profile for Warehouse Permission",
+				warehouse=test_warehouse.name
+			)
+			pos_profile.save()
+			
+			# Create a test user
+			test_user = "test_pos_user@example.com"
+			if not frappe.db.exists("User", test_user):
+				user_doc = frappe.get_doc({
+					"doctype": "User",
+					"email": test_user,
+					"first_name": "Test POS User",
+					"user_type": "System User",
+					"send_welcome_email": 0
+				})
+				user_doc.insert()
+			
+			# Create user permission for a different warehouse (not the one in POS Profile)
+			different_warehouse = "_Test Warehouse - _TC"
+			user_permission = frappe.get_doc({
+				"doctype": "User Permission",
+				"user": test_user,
+				"allow": "Warehouse",
+				"for_value": different_warehouse,
+				"apply_to_all_doctypes": 1
+			})
+			user_permission.insert()
+			
+			# Set user and try to create POS Invoice
+			frappe.set_user(test_user)
+			
+			# This should not raise a permission error
+			pos_inv = frappe.new_doc("POS Invoice")
+			pos_inv.pos_profile = pos_profile.name
+			pos_inv.customer = "_Test Customer"
+			pos_inv.company = "_Test Company"
+			
+			# Call set_missing_values which should handle warehouse permission gracefully
+			pos_inv.set_missing_values()
+			
+			# The warehouse should be set to the one the user has permission to
+			# or remain unset if no permission exists
+			if pos_inv.set_warehouse:
+				# Verify user has permission to the set warehouse
+				self.assertTrue(frappe.has_permission("Warehouse", "read", pos_inv.set_warehouse))
+			
+			# Test should pass without throwing PermissionError
+			self.assertTrue(True, "POS Invoice creation with warehouse permission restrictions should not fail")
+			
+		except Exception as e:
+			# If we get a PermissionError, the fix didn't work
+			if "PermissionError" in str(type(e)):
+				self.fail(f"POS Invoice creation failed with PermissionError: {str(e)}")
+			else:
+				# Re-raise other exceptions
+				raise e
+		finally:
+			frappe.db.rollback(save_point="before_test_warehouse_permission")
+			frappe.set_user("Administrator")
+
 
 def create_pos_invoice(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: Fix warehouse permission error in POS Invoice creation

Here's the [detailed postmortem analysis](https://app.clete.ai/execution?exec_id=e0eaa9747c&entity_ref=user_1&no_setup_check=1)