### PR TITLE
Clete AI PR: Fix warehouse permission error in POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -636,7 +636,16 @@ class POSInvoice(SalesInvoice):
 			self.account_for_change_amount = (
 				profile.get("account_for_change_amount") or self.account_for_change_amount
 			)
-			self.set_warehouse = profile.get("warehouse") or self.set_warehouse
+			
+			# Handle warehouse with proper permission checking
+			profile_warehouse = profile.get("warehouse")
+			if (profile_warehouse 
+			and frappe.db.exists("Warehouse", profile_warehouse) 
+			and frappe.has_permission("Warehouse", "read", profile_warehouse)):
+				self.set_warehouse = profile_warehouse
+			elif not profile_warehouse and not self.set_warehouse:
+				# Only clear if both profile and current value are empty
+				self.set_warehouse = None
 
 			for fieldname in (
 				"currency",

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -973,6 +973,69 @@ class TestPOSInvoice(IntegrationTestCase):
 			frappe.db.rollback(save_point="before_test_delivered_serial_no_case")
 			frappe.set_user("Administrator")
 
+	def test_warehouse_permission_validation(self):
+		"""Test that POS Invoice handles warehouse permissions correctly when strict user permissions are applied"""
+		from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
+		
+		# Create a test warehouse that the user won't have permission to
+		test_warehouse = frappe.get_doc({
+			"doctype": "Warehouse",
+			"warehouse_name": "Test Restricted Warehouse",
+			"company": "_Test Company"
+		}).insert()
+		
+		try:
+			# Create a POS profile with the restricted warehouse
+			pos_profile = make_pos_profile(
+				company="_Test Company",
+				warehouse=test_warehouse.name,
+				income_account="Sales - _TC",
+				expense_account="Cost of Goods Sold - _TC",
+				write_off_account="Write Off - _TC"
+			)
+			
+			# Create POS Invoice - this should not fail even if user doesn't have warehouse permission
+			pos_inv = frappe.get_doc({
+				"doctype": "POS Invoice",
+				"company": "_Test Company",
+				"customer": "_Test Customer",
+				"pos_profile": pos_profile.name,
+				"items": [{
+					"item_code": "_Test Item",
+					"qty": 1,
+					"rate": 100,
+					"warehouse": "_Test Warehouse - _TC"
+				}],
+				"payments": [{
+					"mode_of_payment": "Cash",
+					"amount": 100
+				}]
+			})
+			
+			# This should not raise a permission error
+			pos_inv.set_missing_values()
+			
+			# Verify that warehouse was not set if user doesn't have permission
+			# or was set correctly if user has permission
+			if frappe.has_permission("Warehouse", "read", test_warehouse.name):
+				self.assertEqual(pos_inv.set_warehouse, test_warehouse.name)
+			else:
+				# Should either be None or the existing value, not the restricted warehouse
+				self.assertNotEqual(pos_inv.set_warehouse, test_warehouse.name)
+			
+			pos_inv.insert()
+			pos_inv.submit()
+			
+		finally:
+			# Clean up
+			if 'pos_inv' in locals() and pos_inv.docstatus == 1:
+				pos_inv.cancel()
+			if 'pos_inv' in locals():
+				pos_inv.delete()
+			if 'pos_profile' in locals():
+				pos_profile.delete()
+			test_warehouse.delete()
+
 
 def create_pos_invoice(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
This is a PR opened by AI tool [Clete AI](https://www.clete.ai) to implement changes: Fix warehouse permission error in POS Invoice

Here's the [detailed postmortem analysis](https://app.clete.ai/execution?exec_id=c7e8571ec0&entity_ref=user_1&no_setup_check=1)